### PR TITLE
6 concat1ple regression test fails

### DIFF
--- a/plexil2maude/tests/TestSuite.hs
+++ b/plexil2maude/tests/TestSuite.hs
@@ -69,6 +69,7 @@ testsLegacy =
         ,testsParseNodeCondition
         ,testLookups
         ,testUpdate
+        ,testsParseConcat
         ,testGroup "Parse internal equality expression" $
             map (testify'' elementVisitor)
                 [("An icarous node failure equality expression ",
@@ -549,6 +550,40 @@ testsParseNodeState =
         map (testify' parseNodeState)
             [("Identifier", "<NodeStateVariable><NodeRef dir=\"child\">NodeIdentifier</NodeRef></NodeStateVariable>", "NodeIdentifier")
             ,("StateValue", "<NodeStateValue>FAILING</NodeStateValue>", "failing")
+            ]
+
+testsParseConcat :: TestTree
+testsParseConcat =
+    testGroup "parseConcat" $
+        map (testify'' elementVisitor)
+            [("2-concat", [r|
+              <Concat ColNo="47" LineNo="11">
+                <StringValue>one</StringValue>
+                <StringValue>two</StringValue>
+              </Concat>
+            |],[r|(const(val("one")) + const(val("two")))|])
+            ,("3-concat", [r|
+              <Concat ColNo="47" LineNo="11">
+                <StringValue>one</StringValue>
+                <StringValue>two</StringValue>
+                <StringValue>three</StringValue>
+              </Concat>
+            |],[r|(const(val("one")) + (const(val("two")) + const(val("three"))))|])
+            ,("4-concat", [r|
+              <Concat ColNo="47" LineNo="11">
+                <StringValue>one</StringValue>
+                <StringValue>two</StringValue>
+                <StringValue>three</StringValue>
+                <StringValue>four</StringValue>
+              </Concat>
+            |],[r|(const(val("one")) + (const(val("two")) + (const(val("three")) + const(val("four")))))|])
+            ,("3-concat with var", [r|
+              <Concat ColNo="47" LineNo="11">
+                <StringValue>one</StringValue>
+                <StringValue>two</StringValue>
+                <StringVariable>bar</StringVariable>
+              </Concat>
+            |],[r|(const(val("one")) + (const(val("two")) + var('bar)))|])
             ]
 
 testsParseNodeOutcomeVariable :: TestTree

--- a/semantics/test/unit/expressions/operators.maude
+++ b/semantics/test/unit/expressions/operators.maude
@@ -1,0 +1,39 @@
+mod TEST-OPERATORS is
+    pr TEST-BASE .
+
+    op operators--tests : -> TestResults .
+    eq operators--tests = begin tests
+
+***        assert "2-concat" from
+***            testExpression(
+***                const(val("foo")) + const(val("bar"))
+***            )
+***        reaches
+***            testExpression(
+***                const(val("foobar"))
+***            )
+***        end
+
+        assert "3-concat-v1" from
+            testExpression(
+                (const(val("foo")) + const(val("bar"))) + const(val("fun"))
+            )
+        reaches
+            testExpression(
+                const(val("foobarfun"))
+            )
+        end
+
+        assert "3-concat-v2" from
+            testExpression(
+                const(val("foo")) + (const(val("bar")) + const(val("fun")))
+            )
+        reaches
+            testExpression(
+                const(val("foobarfun"))
+            )
+        end
+
+    end tests .
+
+endm

--- a/semantics/test/unit/expressions/operators.maude
+++ b/semantics/test/unit/expressions/operators.maude
@@ -4,15 +4,15 @@ mod TEST-OPERATORS is
     op operators--tests : -> TestResults .
     eq operators--tests = begin tests
 
-***        assert "2-concat" from
-***            testExpression(
-***                const(val("foo")) + const(val("bar"))
-***            )
-***        reaches
-***            testExpression(
-***                const(val("foobar"))
-***            )
-***        end
+        assert "2-concat" from
+            testExpression(
+                const(val("foo")) + const(val("bar"))
+            )
+        reaches
+            testExpression(
+                const(val("foobar"))
+            )
+        end
 
         assert "3-concat-v1" from
             testExpression(

--- a/semantics/test/unit/expressions/test.maude
+++ b/semantics/test/unit/expressions/test.maude
@@ -1,8 +1,10 @@
 in id-sanitizer.maude
+in operators.maude
 
 mod TEST--EXPRESSIONS is
 
   pr TEST--ID-SANITIZER .
+  pr TEST-OPERATORS .
 
   op expressions--tests : -> TestResults .
 
@@ -10,6 +12,7 @@ mod TEST--EXPRESSIONS is
     id-sanitizer--tests
     + getFullyQualifiedVariableId--tests
     + getFullyQualifiedNodeId--tests
+    + operators--tests
     .
 
 endm


### PR DESCRIPTION
Introduce parsing for concat and creating tests.

Concat remains a binary operator '+', so parsing applies parentheses.