### PR TITLE
8 concat2psx regression test fails

### DIFF
--- a/plexil2maude/apps/PSX2Maude/PrettyMaude.hs
+++ b/plexil2maude/apps/PSX2Maude/PrettyMaude.hs
@@ -59,17 +59,25 @@ instance Pretty State where
     , stValue
     , stType
     }) =
-        text "stateLookup"
-          <> parens (
-            hcat $ punctuate comma
-              [text "'" <> text stName
-              ,text "nilarg"
-               , case stType of PXBoolArray   -> text "array" <> parens (hcat $ punctuate (text " # ") $ map wrapVal $ map text $ (map unValue stValue))
-                                PXIntArray    -> text "array" <> parens (hcat $ punctuate (text " # ") $ map wrapVal $ map text $ (map unValue stValue))
-                                PXRealArray   -> text "array" <> parens (hcat $ punctuate (text " # ") $ map wrapVal $ map text $ (map unValue stValue))
-                                PXStringArray -> text "array" <> parens (hcat $ punctuate (text " # ") $ map wrapVal $ map text $ (map unValue stValue))
-                                _             -> text "val" <> (parens $ text $ unValue $ head stValue)]
-          )
+    text "stateLookup"
+      <> parens (
+        hcat $ punctuate comma
+          [ text "'" <> text stName
+          , text "nilarg"
+          , case stType of
+              PXBoolArray   -> arrayValues
+              PXIntArray    -> arrayValues
+              PXRealArray   -> arrayValues
+              PXStringArray -> arrayValues
+              PXString      -> stringValues
+              _             -> otherValues
+          ]
+      )
+    where
+      arrayValues = text "array" <> parens (hcat $ punctuate (text " # ") $ map wrapVal $ map text $ map unValue stValue)
+      otherValues = text "val" <> parens (text $ unValue $ head stValue)
+      stringValues = text "val" <> parens (doubleQuotes $ text $ unValue $ head stValue)
+
 
 wrapVal :: Doc -> Doc -- wraps document in "val(...)"
 wrapVal doc = text "val" <> parens doc

--- a/plexil2maude/tests/PSX2MaudeTests.hs
+++ b/plexil2maude/tests/PSX2MaudeTests.hs
@@ -343,6 +343,14 @@ testState = testGroup "State"
           State "st" [] [ Value { unValue = "1" }] PXInt
             `testPrettiesAs`
               "stateLookup('st,nilarg,val(1))"
+    ,
+          State "st" [] [ Value { unValue = "one" }] PXString
+            `testPrettiesAs`
+               [r|stateLookup('st,nilarg,val("one"))|]
+    ,
+          State "st" [] [ Value { unValue = "one" }, Value { unValue = "two" }] PXString
+            `testPrettiesAs`
+               [r|stateLookup('st,nilarg,val("one"))|]
     ]
   ]
   where


### PR DESCRIPTION
States of type string were not parsed correctly. Add double quotes when pertinent. Concat2 test now passes.
Create tests accordingly.