### PR TITLE
Support `self` node references

### DIFF
--- a/plexil2maude/plexil2maude.cabal
+++ b/plexil2maude/plexil2maude.cabal
@@ -100,7 +100,7 @@ test-suite test
   type: exitcode-stdio-1.0
   hs-source-dirs: tests, src, apps
   main-is: TestSuite.hs
-  other-modules: PLEXILScript,Benchmarks,GlobalDeclarations,PSX2MaudeTests,Parser,TestArrays,PSX2Maude.PrettyMaude
+  other-modules: PLEXILScript,Benchmarks,GlobalDeclarations,PSX2MaudeTests,Parser,TestArrays,PSX2Maude.PrettyMaude,TestCommon,TestNodeRef
   ghc-options: -Wall
   default-extensions: OverloadedStrings
   build-depends: tasty >= 1.1, tasty-hspec, hspec >= 2, tasty-hunit, base >=4.9, xml-conduit, raw-strings-qq, text, mtl, pretty, containers,

--- a/plexil2maude/tests/TestCommon.hs
+++ b/plexil2maude/tests/TestCommon.hs
@@ -15,19 +15,19 @@ import Text.XML hiding (Name)
 
 import Parser (ParseError)
 
-newtype TestInput  = In String 
+newtype TestInput  = In String
 newtype TestOutput = Out String
 
 testParser :: (Cursor -> Doc) -> [(String,String,String)] -> [TestTree]
-testParser f = map testCaseParser' 
+testParser f = map testCaseParser'
   where
     testCaseParser' (msg,i,o) = testCaseParser f (msg,In i,Out o)
 
 testCaseParser :: (Cursor -> Doc) -> (String, TestInput, TestOutput) -> TestTree
-testCaseParser f (msg,In i,Out o) = 
+testCaseParser f (msg,In i,Out o) =
   testCase msg $
     renderAndClean (f cursor) @?=  renderAndClean (text o)
-    where 
+    where
       renderAndClean = clean . render
         where
           render = renderStyle (style {mode = OneLineMode})
@@ -37,29 +37,29 @@ testCaseParser f (msg,In i,Out o) =
           doc = parseText_ def $ fromString i
 
 testParserGeneric :: (Eq t, Show t) => (Cursor -> t) -> [(String,String,t)] -> [TestTree]
-testParserGeneric f = map testCaseParserGeneric' 
+testParserGeneric f = map testCaseParserGeneric'
   where
     testCaseParserGeneric' (msg,i,o) = testCaseParserGeneric f (msg,In i,o)
 
 testCaseParserGeneric :: (Eq t, Show t) => (Cursor -> t) -> (String, TestInput, t) -> TestTree
-testCaseParserGeneric f (msg,In i,o) = 
+testCaseParserGeneric f (msg,In i,o) =
   testCase msg $
     f cursor @?= o
-    where 
+    where
       cursor = fromDocument doc
         where
           doc = parseText_ def $ fromString i
 
 testErrorParser :: (Cursor -> ParseError Doc) -> [(String,String,String)] -> [TestTree]
-testErrorParser f = map testCaseErrorParser' 
+testErrorParser f = map testCaseErrorParser'
   where
     testCaseErrorParser' (msg,i,o) = testCaseErrorParser f (msg,In i,Out o)
 
 testCaseErrorParser :: (Cursor -> ParseError Doc) -> (String, TestInput, TestOutput) -> TestTree
-testCaseErrorParser f (msg,In i,Out o) = 
+testCaseErrorParser f (msg,In i,Out o) =
   testCase msg $
     renderAndClean <$> (f cursor) @?= return (renderAndClean (text o))
-    where 
+    where
       renderAndClean = clean . render
         where
           render = renderStyle (style {mode = OneLineMode})
@@ -67,3 +67,8 @@ testCaseErrorParser f (msg,In i,Out o) =
       cursor = fromDocument doc
         where
           doc = parseText_ def $ fromString i
+
+getTestCursor :: String -> Cursor
+getTestCursor str = fromDocument doc
+  where
+    doc = parseText_ def $ fromString str

--- a/plexil2maude/tests/TestNodeRef.hs
+++ b/plexil2maude/tests/TestNodeRef.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module TestNodeRef where
+
+import Parser
+import Control.Applicative
+import Control.Monad.Except
+import Data.Char
+import Data.Either
+import Data.Maybe
+-- import Data.List (intersperse)
+-- import qualified Data.Map as M
+import Data.String (fromString)
+-- import Data.Text (Text) --  hiding (map)
+-- import Debug.Trace
+-- import qualified Data.Text as T --  hiding (map)
+import Prelude hiding ((<>)) -- (concat)
+-- import System.Environment
+-- import System.Exit
+-- import Data.Text.Internal.Lazy
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.PrettyPrint
+-- import qualified Text.PrettyPrint as PP
+import Text.RawString.QQ
+import TestCommon
+
+testNodeRef :: TestTree
+testNodeRef =
+  testGroup "Node References"
+    [let c = getTestCursor "<testContext><NodeRef dir=\"self\" /></testContext>"
+      in testCase "self is parsed" $ parseRelativeNodeReference c @?= Right ("","self")
+    ]

--- a/plexil2maude/tests/TestSuite.hs
+++ b/plexil2maude/tests/TestSuite.hs
@@ -31,10 +31,9 @@ import Text.XML.Cursor
 
 import Benchmarks(testBenchmarks)
 import PSX2MaudeTests(testPSX2Maude)
-
-import TestArrays(testArrays)
-
 import TestCommon
+import TestArrays(testArrays)
+import TestNodeRef(testNodeRef)
 
 ------------------------------------------------------------
 ----------    Test helpers
@@ -53,6 +52,7 @@ main = defaultMain $
     ,testBenchmarks
     ,testPSX2Maude
     ,testArrays
+    ,testNodeRef
     ]
 
 testsLegacy :: TestTree
@@ -70,6 +70,19 @@ testsLegacy =
         ,testLookups
         ,testUpdate
         ,testsParseConcat
+        ,testGroup "Different issues" $
+          map (testify'' elementVisitor)
+            [("a failing end condition",
+              [r|
+                <EndCondition>
+                  <EQInternal>
+                    <NodeCommandHandleVariable>
+                      <NodeRef dir="self" />
+                    </NodeCommandHandleVariable>
+                    <NodeCommandHandleValue>COMMAND_SUCCESS</NodeCommandHandleValue>
+                  </EQInternal>
+                </EndCondition>
+              |],"(endc:(cmdHandleIs?(self,CommandSuccess)))")]
         ,testGroup "Parse internal equality expression" $
             map (testify'' elementVisitor)
                 [("An icarous node failure equality expression ",

--- a/semantics/src/compiler.maude
+++ b/semantics/src/compiler.maude
@@ -177,11 +177,12 @@ fmod COMPILER is
   eq  getFullyQualifiedNodeId(I, Q, Cfg) = getFullyQualifiedNodeId'(I,Q,Cfg,Q) [owise] .
 
     op getFullyQualifiedNodeId' : Identifier Qualified Configuration Qualified -> Qualified .
-    eq getFullyQualifiedNodeId'(I,   nilq, < I      : Cls | AtS > Cfg, Q') = I .
-    eq getFullyQualifiedNodeId'(I,      I, < I      : Cls | AtS > Cfg, Q') = I .
-    eq getFullyQualifiedNodeId'(I,     NQ, < I . NQ : Cls | AtS > Cfg, Q') = (I . NQ) [owise] .
-    eq getFullyQualifiedNodeId'(I, I' . Q,                        Cfg, Q') = getFullyQualifiedNodeId'(I, Q, Cfg, Q') [owise] .
-    eq getFullyQualifiedNodeId'(I,      Q,                        Cfg, Q') = unresolvedNode(I,Q') [owise] .
+    eq getFullyQualifiedNodeId'(self,      Q,                        Cfg, Q') = Q' .
+    eq getFullyQualifiedNodeId'(I   ,   nilq, < I      : Cls | AtS > Cfg, Q') = I [owise] .
+    eq getFullyQualifiedNodeId'(I   ,      I, < I      : Cls | AtS > Cfg, Q') = I [owise] .
+    eq getFullyQualifiedNodeId'(I   ,     NQ, < I . NQ : Cls | AtS > Cfg, Q') = (I . NQ) [owise] .
+    eq getFullyQualifiedNodeId'(I   , I' . Q,                        Cfg, Q') = getFullyQualifiedNodeId'(I, Q, Cfg, Q') [owise] .
+    eq getFullyQualifiedNodeId'(I   ,      Q,                        Cfg, Q') = unresolvedNode(I,Q') [owise] .
 
 
   op getFullyQualifiedVariableId : Qualified Qualified Configuration -> Qualified .

--- a/semantics/test/unit/compiler/id-sanitizer.maude
+++ b/semantics/test/unit/compiler/id-sanitizer.maude
@@ -1,14 +1,15 @@
-mod TEST--ID-SANITIZER is
+mod TEST--COMPILER--ID-SANITIZER is
 
 pr TEST-BASE .
 
-
-op id-sanitizer--tests : -> TestResults .
-eq id-sanitizer--tests =
-    id-sanitizer--expressions--tests
-    + test--expressions--id-sanitizer--pairs
-    + id-sanitizer--attributes--tests .
-
+op test--compiler--id-sanitizer : -> TestResults .
+eq test--compiler--id-sanitizer =
+    test--id-sanitizer--on-expressions
+    + test--id-sanitizer--on-pairs
+    + test--id-sanitizer--on-attributes
+    + test--getFullyQualifiedVariableId
+    + test--getFullyQualifiedNodeId
+    .
 
 vars Cfg      : Configuration .
 vars I I'     : Identifier .
@@ -17,8 +18,8 @@ vars E E'     : Expression .
 vars Q Q' Q'' : NeQualified .
 vars QV QW    : NeQualified .
 
-op id-sanitizer--attributes--tests : -> TestResults .
-ceq id-sanitizer--attributes--tests =
+op test--id-sanitizer--on-attributes : -> TestResults .
+ceq test--id-sanitizer--on-attributes =
 begin tests
 
     assert "repeatc: attribute is sanitized" from
@@ -156,8 +157,8 @@ if
     /\ E' := isStatus?(getFullyQualifiedNodeId(I,Q,Cfg),waiting)
 .
 
-op test--expressions--id-sanitizer--pairs : -> TestResults .
-eq test--expressions--id-sanitizer--pairs =
+op test--id-sanitizer--on-pairs : -> TestResults .
+eq test--id-sanitizer--on-pairs =
 begin tests
   assert "sanitize ids on no pairs " from
     somePairs(
@@ -195,8 +196,8 @@ end tests
 .
 
 
-op id-sanitizer--expressions--tests : -> TestResults .
-ceq id-sanitizer--expressions--tests =
+op test--id-sanitizer--on-expressions : -> TestResults .
+ceq test--id-sanitizer--on-expressions =
 begin tests
 
     assert "An `isFailure?` expression computes its fully qualified node id" from
@@ -522,8 +523,8 @@ if
 .
 
 
-op getFullyQualifiedVariableId--tests : -> TestResults .
-ceq getFullyQualifiedVariableId--tests =
+op test--getFullyQualifiedVariableId : -> TestResults .
+ceq test--getFullyQualifiedVariableId =
 begin tests
 
     assert "A top level identifier at the top context returns itself if it exists or `unresolvedVariable` if it doesn't" from
@@ -754,8 +755,8 @@ if Cfg:Configuration :=
     < 'M_B . 'C . 'B . 'A : memory | none >
 .
 
-op getFullyQualifiedNodeId--tests : -> TestResults .
-ceq getFullyQualifiedNodeId--tests =
+op test--getFullyQualifiedNodeId : -> TestResults .
+ceq test--getFullyQualifiedNodeId =
 begin tests
 
     assert "A top level identifier returns the identifier if it exists, otherwise `unresolvedNode`" from

--- a/semantics/test/unit/compiler/id-sanitizer.maude
+++ b/semantics/test/unit/compiler/id-sanitizer.maude
@@ -841,6 +841,20 @@ begin tests
         )
     end
 
+    assert "A `self` id returns its context as the full qualified id" from
+        testQualified(
+            getFullyQualifiedNodeId(
+                self,
+                'B . 'A,
+                Cfg:Configuration
+            )
+        )
+        reaches
+        testQualified(
+            'B . 'A
+        )
+    end
+
     assert "A duplicated fully qualified identifier of a node returns an `ambiguity`" from
         testQualified(
             getFullyQualifiedNodeId(

--- a/semantics/test/unit/compiler/test.maude
+++ b/semantics/test/unit/compiler/test.maude
@@ -1,15 +1,18 @@
 load update.maude
+load id-sanitizer.maude
 
 mod TEST--COMPILER is
 
 pr COMPILER .
 pr TEST-BASE .
 pr TEST--COMPILER--UPDATE .
+pr TEST--COMPILER--ID-SANITIZER .
 
-op compiler--tests : -> TestResults .
-eq compiler--tests =
-    compile--compiler--tests
-    + test--compiler--update .
+op test--compiler : -> TestResults .
+eq test--compiler =
+    test--compiler--compile
+    + test--compiler--update
+    + test--compiler--id-sanitizer .
 
 op anEmptyNode : -> PlexilEmpty .
 eq anEmptyNode = empty('aNode, nilocdecl, none) .
@@ -19,8 +22,8 @@ var PrePL : PrePlexilList .
 op aListNodeEmbedding : PrePlexilList -> PlexilList .
 eq aListNodeEmbedding(PrePL) = list('aListNode, nilocdecl, none, PrePL) .
 
-op compile--compiler--tests : -> TestResults .
-eq compile--compiler--tests =
+op test--compiler--compile : -> TestResults .
+eq test--compiler--compile =
 begin tests
 
     assert "compiler__compile(PL) add by default an empty environment generator" from

--- a/semantics/test/unit/expressions/test.maude
+++ b/semantics/test/unit/expressions/test.maude
@@ -1,18 +1,13 @@
-in id-sanitizer.maude
 in operators.maude
 
 mod TEST--EXPRESSIONS is
 
-  pr TEST--ID-SANITIZER .
   pr TEST-OPERATORS .
 
   op expressions--tests : -> TestResults .
 
   eq expressions--tests =
-    id-sanitizer--tests
-    + getFullyQualifiedVariableId--tests
-    + getFullyQualifiedNodeId--tests
-    + operators--tests
+    operators--tests
     .
 
 endm

--- a/semantics/test/unit/suite.maude
+++ b/semantics/test/unit/suite.maude
@@ -26,7 +26,7 @@ mod TEST-SUITE is
     + expressions--tests
     + test--evaluation
     + model-checking--tests
-    + compiler--tests
+    + test--compiler
     + interface--tests
     +
 begin tests


### PR DESCRIPTION
`SynchronousCommand` translations were failing because of unsupported `self` node references in the PLX files. The provided example seems to work.